### PR TITLE
Fix Dockerfile detection

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -46,7 +46,7 @@ var launchCmd = &cobra.Command{
 			panic(sshAddErr)
 		}
 
-		if utils.FileExists("./dockerfile") {
+		if utils.FileExists("./Dockerfile") {
 			pterm.Info.Println("Dockerfile detected - scanning file for details")
 		} else {
 			pterm.Error.Println("No dockerfiles found in current directory.")


### PR DESCRIPTION
While "kicking" the tires, I found that sidekick couldn't find the `Dockerfile`. This change should fix it.