### PR TITLE
Enhance some CLI Command Descriptions

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -237,14 +237,4 @@ to quickly create a Cobra application.`,
 }
 
 func init() {
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// composeCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// composeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -33,13 +33,9 @@ import (
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Deploy a new version of your application to your VPS using Sidekick",
+	Long: `This command deploys a new version o your application to your VPS. 
+It assumes that your VPS is already configured and that your application is ready for deployment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if configErr := utils.ViperInit(); configErr != nil {
 			pterm.Error.Println("Sidekick config not found - Run sidekick init")
@@ -160,14 +156,4 @@ Run sidekick launch`)
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// deployCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// deployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -34,7 +34,7 @@ import (
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "Deploy a new version of your application to your VPS using Sidekick",
-	Long: `This command deploys a new version o your application to your VPS. 
+	Long: `This command deploys a new version of your application to your VPS. 
 It assumes that your VPS is already configured and that your application is ready for deployment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if configErr := utils.ViperInit(); configErr != nil {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -54,14 +54,4 @@ These encrypted secrets will be securely stored and used by your application dur
 
 func init() {
 	launchCmd.AddCommand(envCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// envCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// envCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -30,12 +30,8 @@ import (
 var envCmd = &cobra.Command{
 	Use:   "env",
 	Short: "Prepare env variable secrets by encrypting them before deployment",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Long: `This command allows you to encrypt sensitive environment variables, such as API keys and database credentials, before deploying your application. 
+These encrypted secrets will be securely stored and used by your application during runtime, ensuring that your sensitive information is not exposed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.ViperInit()
 		envFile, envFileErr := os.ReadFile("./.env")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -159,14 +159,4 @@ var initCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(initCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// initCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// initCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,7 +32,7 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Init sidekick CLI and configure your VPS to host your apps",
 	Long: `This command will run you throgh the setup steps to get sidekick loaded on your VPS.
-		You wil neede to provide your VPS IPv4 address and a registery to host your docker images.
+		You wil neede to provide your VPS IPv4 address and a registry to host your docker images.
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
 		pterm.DefaultBasicText.Println("Welcome to Sidekick. We need to collect some details from you first")

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -240,14 +240,4 @@ var launchCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(launchCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// launchCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// launchCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -32,13 +32,8 @@ import (
 // previewCmd represents the preview command
 var previewCmd = &cobra.Command{
 	Use:   "preview",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Deploy a preview environment for your application",
+	Long:  `Sidekick allows you to deploy preview environment based on commit hash`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if configErr := utils.ViperInit(); configErr != nil {
 			pterm.Error.Println("Sidekick config not found - Run sidekick init")
@@ -210,13 +205,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	deployCmd.AddCommand(previewCmd)
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// previewCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// previewCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,6 @@ var rootCmd = &cobra.Command{
 	Use:   "sidekick",
 	Short: "CLI to self-host all your apps on a sinlge VPS without vendor locking",
 	Long:  `With sidekick you can deploy any number of applications to a single VPS, connect multiple domains and much more.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -40,13 +37,5 @@ func Execute() {
 }
 
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.sidekick.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }


### PR DESCRIPTION
I’ve updated the command descriptions that were previously using Cobra’s default placeholder text.
The new descriptions provide more clarity and correctness