### PR TITLE
Parsing `EXPORT ` from Dockerfile on launch

### DIFF
--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -68,8 +68,8 @@ var LaunchCmd = &cobra.Command{
 
 		appPort := ""
 		for _, line := range strings.Split(string(res), "\n") {
-			if strings.HasPrefix(line, "EXPOSE") {
-				appPort = line[len(line)-4:]
+			if strings.HasPrefix(line, "EXPOSE ") {
+				appPort = strings.TrimPrefix(line, "EXPOSE ")
 			}
 		}
 


### PR DESCRIPTION
If in Dockerfile there was `EXPOSE 80`, the current implementation did extrude `E 80`.

Because of that you would receive 
`panic: strconv.ParseUint: parsing "E 80": invalid syntax`.

Trimming prefix should do the trick.