### PR TITLE
[WIP] Container Providers and other fixes

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -123,7 +123,11 @@ It assumes that your VPS is already configured and that your application is read
 
 			cwd, _ := os.Getwd()
 			imgFileName := fmt.Sprintf("%s-latest.tar", appConfig.Name)
-			dockerBuildCmd := exec.Command("docker", "build", "--tag", appConfig.Name, "--progress=plain", "--platform=linux/amd64", cwd)
+			localContainerProvider := "docker"
+			if utils.CommandExists("podman") {
+				localContainerProvider = "podman"
+			}
+			dockerBuildCmd := exec.Command(localContainerProvider, "build", "--tag", appConfig.Name, "--progress=plain", "--platform=linux/amd64", cwd)
 			dockerBuildCmdErrPipe, _ := dockerBuildCmd.StderrPipe()
 			go render.SendLogsToTUI(dockerBuildCmdErrPipe, p)
 
@@ -135,7 +139,7 @@ It assumes that your VPS is already configured and that your application is read
 
 			p.Send(render.NextStageMsg{})
 
-			imgSaveCmd := exec.Command("docker", "save", "-o", imgFileName, appConfig.Name)
+			imgSaveCmd := exec.Command(localContainerProvider, "save", "-o", imgFileName, appConfig.Name)
 			imgSaveCmdErrPipe, _ := imgSaveCmd.StderrPipe()
 			go render.SendLogsToTUI(imgSaveCmdErrPipe, p)
 

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -94,7 +94,7 @@ var LaunchCmd = &cobra.Command{
 		}
 
 		// make a docker service
-		imageName := appName
+		imageName := "localhost/" + appName
 		newService := utils.DockerService{
 			Image:   imageName,
 			Restart: "unless-stopped",
@@ -156,7 +156,11 @@ var LaunchCmd = &cobra.Command{
 			p.Send(render.NextStageMsg{})
 
 			cwd, _ := os.Getwd()
-			dockerBuildCmd := exec.Command("docker", "build", "--tag", appName, "--progress=plain", "--platform=linux/amd64", cwd)
+			localContainerProvider := "docker"
+			if utils.CommandExists("podman") {
+				localContainerProvider = "podman"
+			}
+			dockerBuildCmd := exec.Command(localContainerProvider, "build", "--tag", appName, "--progress=plain", "--platform=linux/amd64", cwd)
 			dockerBuildCmdErrPipe, _ := dockerBuildCmd.StderrPipe()
 			go render.SendLogsToTUI(dockerBuildCmdErrPipe, p)
 
@@ -169,7 +173,7 @@ var LaunchCmd = &cobra.Command{
 			p.Send(render.NextStageMsg{})
 
 			imgFileName := fmt.Sprintf("%s-latest.tar", appName)
-			imgSaveCmd := exec.Command("docker", "save", "-o", imgFileName, appName)
+			imgSaveCmd := exec.Command(localContainerProvider, "save", "-o", imgFileName, appName)
 			imgSaveCmdErrPipe, _ := imgSaveCmd.StderrPipe()
 			go render.SendLogsToTUI(imgSaveCmdErrPipe, p)
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -205,3 +205,8 @@ func WriteEnvFile(filename string, env map[string]string) error {
 	}
 	return nil
 }
+
+func CommandExists(command string) bool {
+	_, err := exec.LookPath(command)
+	return err == nil
+}


### PR DESCRIPTION
# Discovery of alternative local container providers
NOTE: in the current state this is just a proof of concept to unblock me on a project, If I can get the go ahead to complete the implementation I will update this PR with the full implementation and remove this note, see todo section.

## Motivation
1. I use `podman` on my development machine, and its api is mostly compatible with docker
2. [RedHat (biased source) has a nice writeup of why to use `podman`](https://www.redhat.com/en/blog/5-reasons-choose-podman-2025)
3. I like sidekick's design and want to expand it

## Other changes
I discovered the `image` name does not include `localhost/` before it when loaded into the vps, this may be a `podman` specific issue or its simply a bug. Since Sidekick does not support registry (that i know of), i think it makes sense to have images loaded with `localhost/<imageName>`

## TODO

- [ ] determine local container runtime earlier (deduplicate the POC)
- [ ] support `podman` as a remote container provider (on the VPS)


